### PR TITLE
Add directional clustering as default (similar to umi-tools)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+## Our Pledge
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone.
+
+## Our Standards
+Examples of behaviour that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language.
+- Being respectful of differing viewpoints and experiences.
+- Gracefully accepting constructive criticism.
+- Focusing on what is best for the community.
+- Showing empathy towards other community members.
+
+Examples of unacceptable behaviour by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances.
+- Trolling, insulting/derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Our Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable
+behaviour and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behaviour.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviour that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event. Representation of a
+project may be further defined and clarified by project maintainers.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be
+reported by contacting the project team at mailto:jlaros@fixedpoint.nl. The
+project team will review and investigate all complaints, and will respond in a
+way that it deems appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an
+incident. Further details of specific enforcement policies may be posted
+separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.4, available at
+[http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+Please follow these guidelines if you would like to contribute to the project.
+
+---
+
+## Table of Contents
+Please read through these guidelines before you get started:
+
+1. [Questions & Concerns](#questions--concerns)
+2. [Issues & Bugs](#issues--bugs)
+3. [Feature Requests](#feature-requests)
+4. [Submitting Pull Requests](#submitting-pull-requests)
+5. [Code Style](#code-style)
+
+## Questions & Concerns
+If you have any questions about using or developing for this project, reach out
+to @jfjlaros or send an [email][email].
+
+## Issues & Bugs
+Submit an [issue][issues] or [pull request][compare] with a fix if you find any
+bugs in the project. See [below](#submitting-pull-requests) for instructions on
+sending in pull requests, and be sure to reference the [code style
+guide](#code-style) first!
+
+When submitting an issue or pull request, make sure you are as detailed as
+possible and fill in all answers to questions asked in the templates. For
+example, an issue that simply states "X/Y/Z is not working!" will be closed.
+
+## Feature Requests
+Submit an [issue][issues] to request a new feature. Features fall into one of
+two categories:
+
+1. **Major**: Major changes should be discussed with me via [email][email]. I am
+   always open to suggestions and will get back to you as soon as I can!
+2. **Minor**: A minor feature can simply be added via a [pull request][compare].
+
+## Submitting Pull Requests
+Before you do anything, make sure you check the current list of [pull
+requests][pull] to ensure you are not duplicating anyone's work. Then, do the
+following:
+
+1. Fork the repository and make your changes in a git branch: `git checkout -b
+   my-branch base-branch`
+2. Read and follow the [code style guidelines](#code-style).
+3. Make sure your feature or fix does not break the project! Test thoroughly.
+4. Commit your changes, and be sure to leave a detailed commit message.
+5. Push your branch to your forked repo on GitHub: `git push origin my-branch`
+6. [Submit a pull request][compare] and hold tight!
+7. If any changes are requested by the project maintainers, make them and
+   follow this process again until the changes are merged in.
+
+## Code Style
+Please follow the coding style conventions detailed below:
+
+- [Google C++ Style Guide][cppguide].
+- [Doxygen][doxygen].
+
+
+[email]: mailto:jlaros@fixedpoint.nl
+[issues]: https://github.com/jfjlaros/dedup/issues/new
+[compare]: https://github.com/jfjlaros/dedup/compare
+[pull]: https://github.com/jfjlaros/dedup/pulls
+[cppguide]: https://google.github.io/styleguide/cppguide.html
+[doxygen]: http://doxygen.nl/

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behaviour:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Ubuntu Desktop 18.04]
+ - Version [e.g. 0.0.14]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've
+considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+# Submit a pull request
+Thank you for submitting a pull request. To speed up the review process, please
+ensure that everything below is true:
+
+1. This is not a duplicate of an [existing pull request][1].
+2. No existing features have been broken without good reason.
+3. Your commit messages are detailed
+4. The code style [guidelines][2] have been followed.
+5. Documentation has been updated to reflect your changes.
+6. Tests have been added or updated to reflect your changes.
+7. All tests pass.
+
+Any questions should be directed to @jfjlaros.
+
+---
+
+Replace any ":question:" below with information about your pull request.
+
+## Pull Request Details
+Provide details about your pull request and what it adds, fixes, or changes.
+
+:question:
+
+## Breaking Changes
+Describe what features are broken by this pull request and why, if any.
+
+:question:
+
+## Issues Fixed
+Enter the issue numbers resolved by this pull request below, if any.
+
+1. :question:
+
+## Other Relevant Information
+Provide any other important details below.
+
+:question:
+
+[1]: https://github.com/jfjlaros/dedup/pulls
+[2]: https://github.com/jfjlaros/dedup/blob/master/docs/CONTRIBUTING.md#code-style

--- a/.github/workflows/cpp-library.yml
+++ b/.github/workflows/cpp-library.yml
@@ -1,0 +1,26 @@
+name: build
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install catch g++-11 valgrind
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+      - name: Install submodules
+        run: |
+          git submodule init
+          git submodule update
+      - name: Test with catch
+        run: |
+          cd tests
+          make check

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ LIBS := cluster fastq log ../lib/commandIO/src/error \
   ../lib/fastp/src/fastareader ../lib/fastp/src/options
 
 
-CC := g++
+CC := g++-10
 CC_ARGS := -O2 -fcoroutines -std=c++20
 LD_ARGS := -lisal -ldeflate
 LD_STATIC_ARGS := -L../lib/isa-l/.libs/ -static

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,7 @@ LIBS := cluster fastq log ../lib/commandIO/src/error \
   ../lib/fastp/src/fastareader ../lib/fastp/src/options
 
 
-CC := g++-10
+CC := g++
 CC_ARGS := -O2 -fcoroutines -std=c++20
 LD_ARGS := -lisal -ldeflate
 LD_STATIC_ARGS := -L../lib/isa-l/.libs/ -static

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -39,8 +39,7 @@ void assignMaxCluster(NLeaf* leaf, Cluster* cluster) {
     }
   }
 }
-
-/*!
+/*
  * Determine if the count difference between leaf and neighbour is indicative
  * of an error that has been amplified by PCR
  *
@@ -49,6 +48,23 @@ void assignMaxCluster(NLeaf* leaf, Cluster* cluster) {
  */
 bool _pcr_step_size(NLeaf* leaf, NLeaf* neighbour) {
     return leaf->count > 2 * neighbour->count - 1;
+}
+
+/*!
+ * Determine if a is at least 2x b. This is used on the the count difference
+ * between a leaf and its neighbour. If this is the case, neighbour will be
+ * treated as a PCR-amplified error of leaf.
+ */
+bool _at_least_double(int a, int b) {
+    return a > 2 * b -1;
+}
+
+/*!
+ * The inverse of _at_least_double, used to determine if the neighbour is the
+ * true sequence, and leaf a PCR error.
+ */
+bool _at_most_half(int a, int b) {
+    return _at_least_double(b, a);
 }
 
 /*!

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -68,6 +68,27 @@ bool _at_most_half(int a, int b) {
 }
 
 /*!
+ * Traverse neigbhours until a local maximum is reached
+ *
+ * \param leaf Leaf node.
+ */
+
+NLeaf * _max_neighbour(NLeaf* leaf){
+    bool done = false;
+    while (!done) {
+        // Assume we are done, unless we find a double neighbour
+        done = true;
+        for (NLeaf* neighbour: leaf->neighbours) {
+            if (_at_least_double(neighbour->count, leaf->count)) {
+                leaf = neighbour;
+                done = false;
+                break;
+            }
+        }
+    }
+    return leaf;
+}
+/*!
  * Traverse neighbours to assign cluster IDs, using the directional method
  * Only add neighbours that have at least 2x more reads
  *

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -11,7 +11,7 @@ Cluster::Cluster(size_t id) {
 
 
 /*!
- * Assign leaf to cluster
+ * Assign leaf to cluster.
  *
  * \param leaf Leaf node.
  * \param cluster Cluster.
@@ -22,7 +22,7 @@ void _assignLeaf(NLeaf* leaf, Cluster* cluster) {
 }
 
 /*
- * Update the counts for cluster
+ * Update the counts for cluster.
  *
  * \param leaf Leaf node.
  * \param cluster Cluster.
@@ -51,62 +51,57 @@ void assignMaxCluster(NLeaf* leaf, Cluster* cluster) {
 }
 
 /*!
- * Determine if a is at least 2x b. This is used on the the count difference
+ * Determine if a is at least 2b. This is used on the the count difference
  * between a leaf and its neighbour. If this is the case, neighbour will be
  * treated as a PCR-amplified error of leaf.
  */
 bool _atLeastDouble(int a, int b) {
-    return a > 2 * b -1;
+  return a > 2 * b - 1;
 }
 
-/*!
+/*
  * The inverse of _atLeastDouble, used to determine if the neighbour is the
  * true sequence, and leaf a PCR error.
  */
 bool _atMostHalf(int a, int b) {
-    return _atLeastDouble(b, a);
+  return _atLeastDouble(b, a);
 }
 
 /*!
- * Traverse neigbhours until a local maximum is reached
+ * Traverse neigbhours until a local maximum is reached.
  *
  * \param leaf Leaf node.
  */
+NLeaf* max_neighbour(NLeaf* leaf){
+  int i = 0;
+  while (i < leaf->neighbours.size()) {
+    NLeaf* neighbour = leaf->neighbours[i++];
 
-NLeaf * max_neighbour(NLeaf* leaf){
-    int i = 0;
-    while (i < leaf->neighbours.size()) {
-        NLeaf* neighbour = leaf->neighbours[i];
-        // Go to the neighbour and repeat
-        if (_atLeastDouble(neighbour->count, leaf->count) and !neighbour->cluster) {
-            leaf = neighbour;
-            i = 0;
-        }
-        // Try the next neighbour
-        else {
-            i++;
-        }
+    if (not neighbour->cluster and _atLeastDouble(neighbour->count, leaf->count)) {
+      // Go to the neighbour and repeat.
+      leaf = neighbour;
+      i = 0;
     }
-    return leaf;
+  }
+  return leaf;
 }
 
-/*!
+/*
  * Internal function to traverse neighbours to assign cluster ID
  *
  * \param leaf Leaf node.
  * \param cluster Cluster.
  */
 void _assignDirectionalCluster(NLeaf* leaf, Cluster* cluster) {
-  // Assign the leaf to the cluster
   _assignLeaf(leaf, cluster);
   for (NLeaf* neighbour: leaf->neighbours) {
     // If we encounter a neighbour that is unassigned, at most half leaf's
-    // size, we recursively add it to cluster
+    // size, we recursively add it to cluster.
     if (!neighbour->cluster and _atMostHalf(neighbour->count, leaf->count)) {
       // If the neighbour has less than half of the number of reads, the
-      // neighbour belongs to the current cluster
+      // neighbour belongs to the current cluster.
       _assignDirectionalCluster(neighbour, cluster);
-      }
+    }
   }
 }
 
@@ -120,7 +115,6 @@ void _assignDirectionalCluster(NLeaf* leaf, Cluster* cluster) {
  * \param cluster Cluster.
  */
 void assignDirectionalCluster(NLeaf* leaf, Cluster* cluster){
-  // Determine a maximum neighbour
   NLeaf* node = max_neighbour(leaf);
   // Update the maxcount for the cluster using the max node (only once)
   _updateMaxCount(node, cluster);

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -74,17 +74,17 @@ bool _atMostHalf(int a, int b) {
  */
 
 NLeaf * max_neighbour(NLeaf* leaf){
-    bool done = false;
-    while (!done) {
-        // Assume we are done, unless we find a double neighbour
-        done = true;
-        for (NLeaf* neighbour: leaf->neighbours) {
-            // Neighbour count is 2x, and neighbour is not in a cluster yet
-            if (_atLeastDouble(neighbour->count, leaf->count) and !neighbour->cluster) {
-                leaf = neighbour;
-                done = false;
-                break;
-            }
+    int i = 0;
+    while (i < leaf->neighbours.size()) {
+        NLeaf* neighbour = leaf->neighbours[i];
+        // Go to the neighbour and repeat
+        if (_atLeastDouble(neighbour->count, leaf->count) and !neighbour->cluster) {
+            leaf = neighbour;
+            i = 0;
+        }
+        // Try the next neighbour
+        else {
+            i++;
         }
     }
     return leaf;

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -49,16 +49,6 @@ void assignMaxCluster(NLeaf* leaf, Cluster* cluster) {
     }
   }
 }
-/*
- * Determine if the count difference between leaf and neighbour is indicative
- * of an error that has been amplified by PCR
- *
- * \param leaf Leaf node.
- * \param neighbour Leaf node.
- */
-bool _pcr_step_size(NLeaf* leaf, NLeaf* neighbour) {
-    return leaf->count > 2 * neighbour->count - 1;
-}
 
 /*!
  * Determine if a is at least 2x b. This is used on the the count difference
@@ -97,45 +87,6 @@ NLeaf * max_neighbour(NLeaf* leaf){
         }
     }
     return leaf;
-}
-/*!
- * Traverse neighbours to assign cluster IDs, using the directional method
- * Only add neighbours that have at least 2x more reads
- *
- * \param leaf Leaf node.
- * \param cluster Cluster.
- */
-void _assignDirectionalClusterUp(NLeaf* leaf, Cluster* cluster){
-  _assignLeaf(leaf, cluster);
-
-  for (NLeaf* neighbour: leaf->neighbours) {
-    if (!neighbour->cluster) {
-      // If the neighbour has more than 2x the number of reads, the neighbour
-      // is the 'true' sequence
-      if (_pcr_step_size(neighbour, leaf))
-        _assignDirectionalClusterUp(neighbour, cluster);
-    }
-  }
-}
-
-/*!
- * Traverse neighbours to assign cluster IDs, using the directional method
- * Only add neighbours that have at most 2x fewer reads
- *
- * \param leaf Leaf node.
- * \param cluster Cluster.
- */
-void _assignDirectionalClusterDown(NLeaf* leaf, Cluster* cluster){
-  _assignLeaf(leaf, cluster);
-
-  for (NLeaf* neighbour: leaf->neighbours) {
-    if (!neighbour->cluster) {
-      // If the neighbour has more than 2x the number of reads, the neighbour
-      // is the 'true' sequence
-      if (_pcr_step_size(leaf, neighbour))
-        _assignDirectionalClusterDown(neighbour, cluster);
-    }
-  }
 }
 
 /*!

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -90,24 +90,40 @@ NLeaf * max_neighbour(NLeaf* leaf){
 }
 
 /*!
- * Traverse neighbours to assign cluster IDs, using the directional method
+ * Internal function to traverse neighbours to assign cluster ID
  *
  * \param leaf Leaf node.
  * \param cluster Cluster.
  */
-void assignDirectionalCluster(NLeaf* leaf, Cluster* cluster){
+void _assignDirectionalCluster(NLeaf* leaf, Cluster* cluster) {
+  // Assign the leaf to the cluster
   _assignLeaf(leaf, cluster);
-  _updateMaxCount(leaf, cluster);
-
   for (NLeaf* neighbour: leaf->neighbours) {
     // If we encounter a neighbour that is unassigned, at most half leaf's
     // size, we recursively add it to cluster
     if (!neighbour->cluster and _atMostHalf(neighbour->count, leaf->count)) {
       // If the neighbour has less than half of the number of reads, the
       // neighbour belongs to the current cluster
-      assignDirectionalCluster(neighbour, cluster);
+      _assignDirectionalCluster(neighbour, cluster);
       }
   }
+}
+
+/*!
+ * Traverse neighbours to assign cluster IDs, using the directional method
+ *
+ * Also updates the max_count for the cluster after determining a maximum
+ * neighbour
+ *
+ * \param leaf Leaf node.
+ * \param cluster Cluster.
+ */
+void assignDirectionalCluster(NLeaf* leaf, Cluster* cluster){
+  // Determine a maximum neighbour
+  NLeaf* node = max_neighbour(leaf);
+  // Update the maxcount for the cluster using the max node (only once)
+  _updateMaxCount(node, cluster);
+  _assignDirectionalCluster(node, cluster);
 }
 
 /*!

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -79,7 +79,8 @@ NLeaf * max_neighbour(NLeaf* leaf){
         // Assume we are done, unless we find a double neighbour
         done = true;
         for (NLeaf* neighbour: leaf->neighbours) {
-            if (_atLeastDouble(neighbour->count, leaf->count)) {
+            // Neighbour count is 2x, and neighbour is not in a cluster yet
+            if (_atLeastDouble(neighbour->count, leaf->count) and !neighbour->cluster) {
                 leaf = neighbour;
                 done = false;
                 break;

--- a/src/cluster.cc
+++ b/src/cluster.cc
@@ -55,16 +55,16 @@ void assignMaxCluster(NLeaf* leaf, Cluster* cluster) {
  * between a leaf and its neighbour. If this is the case, neighbour will be
  * treated as a PCR-amplified error of leaf.
  */
-bool _at_least_double(int a, int b) {
+bool _atLeastDouble(int a, int b) {
     return a > 2 * b -1;
 }
 
 /*!
- * The inverse of _at_least_double, used to determine if the neighbour is the
+ * The inverse of _atLeastDouble, used to determine if the neighbour is the
  * true sequence, and leaf a PCR error.
  */
-bool _at_most_half(int a, int b) {
-    return _at_least_double(b, a);
+bool _atMostHalf(int a, int b) {
+    return _atLeastDouble(b, a);
 }
 
 /*!
@@ -79,7 +79,7 @@ NLeaf * max_neighbour(NLeaf* leaf){
         // Assume we are done, unless we find a double neighbour
         done = true;
         for (NLeaf* neighbour: leaf->neighbours) {
-            if (_at_least_double(neighbour->count, leaf->count)) {
+            if (_atLeastDouble(neighbour->count, leaf->count)) {
                 leaf = neighbour;
                 done = false;
                 break;
@@ -102,7 +102,7 @@ void assignDirectionalCluster(NLeaf* leaf, Cluster* cluster){
   for (NLeaf* neighbour: leaf->neighbours) {
     // If we encounter a neighbour that is unassigned, at most half leaf's
     // size, we recursively add it to cluster
-    if (!neighbour->cluster and _at_most_half(neighbour->count, leaf->count)) {
+    if (!neighbour->cluster and _atMostHalf(neighbour->count, leaf->count)) {
       // If the neighbour has less than half of the number of reads, the
       // neighbour belongs to the current cluster
       assignDirectionalCluster(neighbour, cluster);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -22,6 +22,7 @@ struct Cluster {
 };
 
 void assignMaxCluster(NLeaf*, Cluster*);
+NLeaf * max_neighbour(NLeaf*);
 void assignDirectionalCluster(NLeaf*, Cluster*);
 map<size_t, size_t> clusterStats(vector<Cluster*>&);
 void freeClusters(vector<Cluster*>&);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -22,7 +22,6 @@ struct Cluster {
 };
 
 void assignMaxCluster(NLeaf*, Cluster*);
-NLeaf * max_neighbour(NLeaf*);
 void assignDirectionalCluster(NLeaf*, Cluster*);
 map<size_t, size_t> clusterStats(vector<Cluster*>&);
 void freeClusters(vector<Cluster*>&);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -21,6 +21,7 @@ struct Cluster {
   Cluster(size_t);
 };
 
-void assignCluster(NLeaf*, Cluster*);
+void assignMaxCluster(NLeaf*, Cluster*);
+void assignDirectionalCluster(NLeaf*, Cluster*);
 map<size_t, size_t> clusterStats(vector<Cluster*>&);
 void freeClusters(vector<Cluster*>&);

--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -93,7 +93,8 @@ vector<Cluster*> findClusters(Trie<4, NLeaf>& trie, bool maximum, ofstream& log)
         assignMaxCluster(result.leaf, cluster);
       }
       else {
-        assignDirectionalCluster(result.leaf, cluster);
+        NLeaf* node = max_neighbour(result.leaf);
+        assignDirectionalCluster(node, cluster);
       }
       clusters.push_back(cluster);
     }

--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -78,11 +78,11 @@ size_t findNeighbours(Trie<4, NLeaf>& trie, size_t distance, ofstream& log) {
  */
 vector<Cluster*> findClusters(Trie<4, NLeaf>& trie, bool maximum, ofstream& log) {
   size_t start{};
-  if (maximum){
-      start = startMessage(log, "Calculating maximum clusters");
+  if (maximum) {
+    start = startMessage(log, "Calculating maximum clusters");
   }
   else {
-      start = startMessage(log, "Calculating directional clusters");
+    start = startMessage(log, "Calculating directional clusters");
   }
   vector<Cluster*> clusters;
   size_t id = 0;

--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -93,8 +93,7 @@ vector<Cluster*> findClusters(Trie<4, NLeaf>& trie, bool maximum, ofstream& log)
         assignMaxCluster(result.leaf, cluster);
       }
       else {
-        NLeaf* node = max_neighbour(result.leaf);
-        assignDirectionalCluster(node, cluster);
+        assignDirectionalCluster(result.leaf, cluster);
       }
       clusters.push_back(cluster);
     }

--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -83,7 +83,7 @@ vector<Cluster*> findClusters(Trie<4, NLeaf>& trie, ofstream& log) {
   for (Result<NLeaf> result: trie.walk()) {
     if (!result.leaf->cluster) {
       Cluster* cluster = new Cluster(id++);
-      assignCluster(result.leaf, cluster);
+      assignMaxCluster(result.leaf, cluster);
       clusters.push_back(cluster);
     }
   }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,34 @@
+EXEC := run_tests
+MAIN := test_lib
+TESTS := test_cluster
+FIXTURES :=
+
+
+CC := g++
+CC_ARGS := -std=c++20 -fcoroutines -Wno-pmf-conversions
+
+
+OBJS := $(addsuffix .o, $(TESTS) $(FIXTURES))
+
+.PHONY: all check clean distclean
+
+
+all: $(EXEC)
+
+$(EXEC): $(MAIN).cc $(OBJS)
+	$(CC) $(CC_ARGS) -o $@ $^
+
+%.o: %.cpp
+	$(CC) $(CC_ARGS) -o $@ -c $<
+
+%.o: %.cc
+	$(CC) $(CC_ARGS) -o $@ -c $<
+
+check: all
+	valgrind ./$(EXEC)
+
+clean:
+	rm -f $(OBJS)
+
+distclean: clean
+	rm -f $(EXEC)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,7 +25,7 @@ $(EXEC): $(MAIN).cc $(OBJS)
 	$(CC) $(CC_ARGS) -o $@ -c $<
 
 check: all
-	valgrind ./$(EXEC)
+	valgrind --error-exitcode=1 --leak-check=full ./$(EXEC) || ((echo "\033[0;31mVALGRIND ERRORS DETECTED\033[0m" && false))
 
 clean:
 	rm -f $(OBJS)

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -29,99 +29,117 @@ TEST_CASE("Test walking a node with no neighbours", "[cluster]"){
 
 TEST_CASE("Test walking node whose neighbour is already assigned", "[cluster]"){
     // Create a more complex setup, of chained leafs
-    NLeaf leaf;
-    leaf.count = 1;
+    NLeaf* leaf = new NLeaf();
+    leaf->count = 1;
 
     //A neighbour that is already in a cluster should not be used
-    NLeaf assigned_neighbour;
+    NLeaf* assigned_neighbour = new NLeaf();
     Cluster* c = new Cluster(2);
-    assigned_neighbour.cluster = c;
-    assigned_neighbour.count = 2;
-    link(&leaf, &assigned_neighbour);
-    REQUIRE(max_neighbour(&leaf) == &leaf);
+    assigned_neighbour->cluster = c;
+    assigned_neighbour->count = 2;
+
+    link(leaf, assigned_neighbour);
+    REQUIRE(max_neighbour(leaf) == leaf);
+
+    delete leaf; delete assigned_neighbour; delete c;
 }
 
 TEST_CASE("Test walking a chain of nodes", "[cluster]"){
     //If there is a neighbour that is not assigned and it conforms to the 2x
     //requirement, it should be used
-    NLeaf leaf;
-    leaf.count = 1;
+    NLeaf* leaf = new NLeaf();
+    leaf->count = 1;
 
-    NLeaf free_neighbour;
-    free_neighbour.count=2;
+    NLeaf* free_neighbour = new NLeaf();
+    free_neighbour->count=2;
 
-    link(&leaf, &free_neighbour);
-    REQUIRE(max_neighbour(&leaf) == &free_neighbour);
+    link(leaf, free_neighbour);
+    REQUIRE(max_neighbour(leaf) == free_neighbour);
 
     //Lets test a third, further neighbour
-    NLeaf third_neighbour;
-    third_neighbour.count=4;
-    link(&free_neighbour, &third_neighbour);
-    REQUIRE(max_neighbour(&leaf) == &third_neighbour);
+    NLeaf* third_neighbour = new NLeaf();
+    third_neighbour->count=4;
+    link(free_neighbour, third_neighbour);
+    REQUIRE(max_neighbour(leaf) == third_neighbour);
 
     //Add one more neighbour, that is not high enough to add
-    NLeaf last_one;
-    last_one.count=7;
-    link(&third_neighbour, &last_one);
+    NLeaf* last_one = new NLeaf();
+    last_one->count=7;
+    link(third_neighbour, last_one);
 
     // Check that the last neighbour was not added, since it was not high
     // enough
-    REQUIRE(max_neighbour(&leaf) == &third_neighbour);
+    REQUIRE(max_neighbour(leaf) == third_neighbour);
+
+    delete leaf; delete free_neighbour; delete third_neighbour; delete last_one;
 }
 
 TEST_CASE("Test assigning to cluster") {
     // Initialise the node counts
-    NLeaf node1 = {2}; // smallest node
-    NLeaf node2 = {4}; // intermediate node
-    NLeaf node3 = {8}; // largest reachable node by walking up in 2x steps
-    NLeaf node4 = {10}; // largest overall node, only reachable from node5
-    NLeaf node5 = {3}; // Only reachable from node5
+    NLeaf* node1 = new NLeaf(); // smallest node
+    node1->count = 2;
+
+    NLeaf* node2 = new NLeaf(); // intermediate node
+    node2->count = 4;
+
+    NLeaf* node3 = new NLeaf(); // largest reachable node by walking up in 2x steps
+    node3->count = 8;
+
+    NLeaf* node4 = new NLeaf(); // largest overall node, only reachable from node5
+    node4->count = 10;
+
+    NLeaf* node5 = new NLeaf(); // Only reachable from node5
+    node5->count = 3;
 
     // Test the inialisation
-    REQUIRE(node4.count == 10);
+    REQUIRE(node4->count == 10);
 
     // Link node1 and node2 together
-    link(&node1, &node2);
+    link(node1, node2);
 
     // Test that node1 and node2 are now linked
-    REQUIRE(node1.neighbours.front() == &node2);
-    REQUIRE(node2.neighbours.front() == &node1);
+    REQUIRE(node1->neighbours.front() == node2);
+    REQUIRE(node2->neighbours.front() == node1);
 
     // Link the rest of the nodes
-    link(&node2, &node3);
-    link(&node3, &node4);
-    link(&node4, &node5);
+    link(node2, node3);
+    link(node3, node4);
+    link(node4, node5);
 
     // Assume we start with node 1, and want to assign them to cluster 1
     Cluster* cluster1 = new Cluster(1);
 
     // Next, we assign all nodes
-    assignDirectionalCluster(&node1, cluster1);
+    assignDirectionalCluster(node1, cluster1);
 
     // Then, the first three nodes should be assigned to cluster 1
-    REQUIRE(node1.cluster->id == 1);
-    REQUIRE(node2.cluster->id == 1);
-    REQUIRE(node3.cluster->id == 1);
+    REQUIRE(node1->cluster->id == 1);
+    REQUIRE(node2->cluster->id == 1);
+    REQUIRE(node3->cluster->id == 1);
 
     // The last two node should not be assigned
-    REQUIRE(!node4.cluster);
-    REQUIRE(!node5.cluster);
+    REQUIRE(!node4->cluster);
+    REQUIRE(!node5->cluster);
 
     // Now we assign node4 to cluster2
     Cluster* cluster2 = new Cluster(2);
-    assignDirectionalCluster(&node4, cluster2);
-    REQUIRE(node4.cluster->id == 2);
-    REQUIRE(node5.cluster->id == 2);
+    assignDirectionalCluster(node4, cluster2);
+    REQUIRE(node4->cluster->id == 2);
+    REQUIRE(node5->cluster->id == 2);
 
     // Check that the cluster size is correct
     REQUIRE(cluster1->size == 14);
     REQUIRE(cluster2->size == 13);
 
     // Check that the maxleaf is correct
-    REQUIRE(cluster1->maxLeaf == &node3);
-    REQUIRE(cluster2->maxLeaf == &node4);
+    REQUIRE(cluster1->maxLeaf == node3);
+    REQUIRE(cluster2->maxLeaf == node4);
 
     // Check that the maxCount is correct
     REQUIRE(cluster1->maxCount == 8);
     REQUIRE(cluster2->maxCount == 10);
+
+    // Clean up
+    delete cluster1; delete cluster2;
+    delete node1; delete node2; delete node3; delete node4; delete node5;
 }

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -94,14 +94,8 @@ TEST_CASE("Test assigning to cluster") {
     // Assume we start with node 1, and want to assign them to cluster 1
     Cluster* cluster1 = new Cluster(1);
 
-    // First, we must find the maximum node reachable from node1
-    NLeaf* node = max_neighbour(&node1);
-
-    // This should be node3
-    REQUIRE(node == &node3);
-
     // Next, we assign all nodes
-    assignDirectionalCluster(node, cluster1);
+    assignDirectionalCluster(&node1, cluster1);
 
     // Then, the first three nodes should be assigned to cluster 1
     REQUIRE(node1.cluster->id == 1);

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -2,15 +2,15 @@
 #include "../src/cluster.cc"
 
 TEST_CASE("Test if a is at least 2x b", "[cluster]"){
-    REQUIRE(_at_least_double(1, 0));
-    REQUIRE(_at_least_double(2, 1));
-    REQUIRE(!_at_least_double(3,2));
+    REQUIRE(_atLeastDouble(1, 0));
+    REQUIRE(_atLeastDouble(2, 1));
+    REQUIRE(!_atLeastDouble(3,2));
 }
 
 TEST_CASE("Test if a is at most half of b", "[cluster]"){
-    REQUIRE(_at_most_half(0, 1));
-    REQUIRE(_at_most_half(1, 2));
-    REQUIRE(!_at_most_half(2, 3));
+    REQUIRE(_atMostHalf(0, 1));
+    REQUIRE(_atMostHalf(1, 2));
+    REQUIRE(!_atMostHalf(2, 3));
 }
 
 TEST_CASE("Test walking a node with no neighbours", "[cluster]"){

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -1,7 +1,6 @@
 #include <catch.hpp>
 #include "../src/cluster.cc"
 
-
 TEST_CASE("Test PCR step size") {
     NLeaf leaf;
     NLeaf neighbour1;
@@ -27,4 +26,40 @@ TEST_CASE("Test if a is at most half of b", "[cluster]"){
     REQUIRE(_at_most_half(0, 1));
     REQUIRE(_at_most_half(1, 2));
     REQUIRE(!_at_most_half(2, 3));
+}
+
+TEST_CASE("Test walking neighbours to find a maximum node", "[cluster]"){
+    NLeaf leaf;
+    leaf.count = 1;
+
+    //A leaf with no neighbours should return itself
+    //NLeaf* lp = &leaf;
+    REQUIRE(_max_neighbour(&leaf) == &leaf);
+
+    //A neighbour that is already in a cluster should not be used
+    NLeaf assigned_neighbour;
+    Cluster* c = new Cluster(2);
+    assigned_neighbour.cluster = c;
+    leaf.neighbours.push_back(&assigned_neighbour);
+    REQUIRE(_max_neighbour(&leaf) == &leaf);
+
+    //If there is a neighbour that is not assigned and it conforms to the 2x
+    //requirement, it should be used
+    NLeaf free_neighbour;
+    free_neighbour.count=2;
+    leaf.neighbours.push_back(&free_neighbour);
+    REQUIRE(_max_neighbour(&leaf) == &free_neighbour);
+
+    //Lets test a third, further neighbour
+    NLeaf third_neighbour;
+    third_neighbour.count=4;
+    free_neighbour.neighbours.push_back(&third_neighbour);
+    REQUIRE(_max_neighbour(&leaf) == &third_neighbour);
+
+    //Add one more neighbour, that is not high enough to add
+    NLeaf last_one;
+    last_one.count=7;
+    third_neighbour.neighbours.push_back(&last_one);
+    // Should not be the last one, but the third one
+    REQUIRE(_max_neighbour(&leaf) == &third_neighbour);
 }

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -1,0 +1,30 @@
+#include <catch.hpp>
+#include "../src/cluster.cc"
+
+
+TEST_CASE("Test PCR step size") {
+    NLeaf leaf;
+    NLeaf neighbour1;
+    NLeaf neighbour2;
+
+    // Check that NLeaf count is initialised to 0
+    REQUIRE(leaf.count == 0);
+
+    // Set the counts
+    leaf.count = 4;
+    neighbour1.count = 2;
+
+    REQUIRE(_pcr_step_size(&leaf, &neighbour1));
+}
+
+TEST_CASE("Test if a is at least 2x b", "[cluster]"){
+    REQUIRE(_at_least_double(1, 0));
+    REQUIRE(_at_least_double(2, 1));
+    REQUIRE(!_at_least_double(3,2));
+}
+
+TEST_CASE("Test if a is at most half of b", "[cluster]"){
+    REQUIRE(_at_most_half(0, 1));
+    REQUIRE(_at_most_half(1, 2));
+    REQUIRE(!_at_most_half(2, 3));
+}

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -1,21 +1,6 @@
 #include <catch.hpp>
 #include "../src/cluster.cc"
 
-TEST_CASE("Test PCR step size") {
-    NLeaf leaf;
-    NLeaf neighbour1;
-    NLeaf neighbour2;
-
-    // Check that NLeaf count is initialised to 0
-    REQUIRE(leaf.count == 0);
-
-    // Set the counts
-    leaf.count = 4;
-    neighbour1.count = 2;
-
-    REQUIRE(_pcr_step_size(&leaf, &neighbour1));
-}
-
 TEST_CASE("Test if a is at least 2x b", "[cluster]"){
     REQUIRE(_at_least_double(1, 0));
     REQUIRE(_at_least_double(2, 1));
@@ -71,7 +56,9 @@ TEST_CASE("Test walking a chain of nodes", "[cluster]"){
     NLeaf last_one;
     last_one.count=7;
     third_neighbour.neighbours.push_back(&last_one);
-    // Should not be the last one, but the third one
+
+    // Check that the last neighbour was not added, since it was not high
+    // enough
     REQUIRE(max_neighbour(&leaf) == &third_neighbour);
 }
 

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -1,6 +1,12 @@
 #include <catch.hpp>
 #include "../src/cluster.cc"
 
+// Helper function to link nodes
+void link(NLeaf* a, NLeaf* b){
+    a->neighbours.push_back(b);
+    b->neighbours.push_back(a);
+}
+
 TEST_CASE("Test if a is at least 2x b", "[cluster]"){
     REQUIRE(_atLeastDouble(1, 0));
     REQUIRE(_atLeastDouble(2, 1));
@@ -31,7 +37,7 @@ TEST_CASE("Test walking node whose neighbour is already assigned", "[cluster]"){
     Cluster* c = new Cluster(2);
     assigned_neighbour.cluster = c;
     assigned_neighbour.count = 2;
-    leaf.neighbours.push_back(&assigned_neighbour);
+    link(&leaf, &assigned_neighbour);
     REQUIRE(max_neighbour(&leaf) == &leaf);
 }
 
@@ -44,29 +50,23 @@ TEST_CASE("Test walking a chain of nodes", "[cluster]"){
     NLeaf free_neighbour;
     free_neighbour.count=2;
 
-    leaf.neighbours.push_back(&free_neighbour);
+    link(&leaf, &free_neighbour);
     REQUIRE(max_neighbour(&leaf) == &free_neighbour);
 
     //Lets test a third, further neighbour
     NLeaf third_neighbour;
     third_neighbour.count=4;
-    free_neighbour.neighbours.push_back(&third_neighbour);
+    link(&free_neighbour, &third_neighbour);
     REQUIRE(max_neighbour(&leaf) == &third_neighbour);
 
     //Add one more neighbour, that is not high enough to add
     NLeaf last_one;
     last_one.count=7;
-    third_neighbour.neighbours.push_back(&last_one);
+    link(&third_neighbour, &last_one);
 
     // Check that the last neighbour was not added, since it was not high
     // enough
     REQUIRE(max_neighbour(&leaf) == &third_neighbour);
-}
-
-// Helper function to link nodes
-void link(NLeaf* a, NLeaf* b){
-    a->neighbours.push_back(b);
-    b->neighbours.push_back(a);
 }
 
 TEST_CASE("Test assigning to cluster") {

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -28,38 +28,118 @@ TEST_CASE("Test if a is at most half of b", "[cluster]"){
     REQUIRE(!_at_most_half(2, 3));
 }
 
-TEST_CASE("Test walking neighbours to find a maximum node", "[cluster]"){
+TEST_CASE("Test walking a node with no neighbours", "[cluster]"){
+
+    // Create a node that is all alone
+    NLeaf alone;
+    //A leaf with no neighbours should return itself
+    REQUIRE(max_neighbour(&alone) == &alone);
+}
+
+TEST_CASE("Test walking node whose neighbour is already assigned", "[cluster]"){
+    // Create a more complex setup, of chained leafs
     NLeaf leaf;
     leaf.count = 1;
-
-    //A leaf with no neighbours should return itself
-    //NLeaf* lp = &leaf;
-    REQUIRE(_max_neighbour(&leaf) == &leaf);
 
     //A neighbour that is already in a cluster should not be used
     NLeaf assigned_neighbour;
     Cluster* c = new Cluster(2);
     assigned_neighbour.cluster = c;
     leaf.neighbours.push_back(&assigned_neighbour);
-    REQUIRE(_max_neighbour(&leaf) == &leaf);
+    REQUIRE(max_neighbour(&leaf) == &leaf);
+}
 
+TEST_CASE("Test walking a chain of nodes", "[cluster]"){
     //If there is a neighbour that is not assigned and it conforms to the 2x
     //requirement, it should be used
+    NLeaf leaf;
+    leaf.count = 1;
+
     NLeaf free_neighbour;
     free_neighbour.count=2;
+
     leaf.neighbours.push_back(&free_neighbour);
-    REQUIRE(_max_neighbour(&leaf) == &free_neighbour);
+    REQUIRE(max_neighbour(&leaf) == &free_neighbour);
 
     //Lets test a third, further neighbour
     NLeaf third_neighbour;
     third_neighbour.count=4;
     free_neighbour.neighbours.push_back(&third_neighbour);
-    REQUIRE(_max_neighbour(&leaf) == &third_neighbour);
+    REQUIRE(max_neighbour(&leaf) == &third_neighbour);
 
     //Add one more neighbour, that is not high enough to add
     NLeaf last_one;
     last_one.count=7;
     third_neighbour.neighbours.push_back(&last_one);
     // Should not be the last one, but the third one
-    REQUIRE(_max_neighbour(&leaf) == &third_neighbour);
+    REQUIRE(max_neighbour(&leaf) == &third_neighbour);
+}
+
+// Helper function to link nodes
+void link(NLeaf* a, NLeaf* b){
+    a->neighbours.push_back(b);
+    b->neighbours.push_back(a);
+}
+
+TEST_CASE("Test assigning to cluster") {
+    // Initialise the node counts
+    NLeaf node1 = {2}; // smallest node
+    NLeaf node2 = {4}; // intermediate node
+    NLeaf node3 = {8}; // largest reachable node by walking up in 2x steps
+    NLeaf node4 = {10}; // largest overall node, only reachable from node5
+    NLeaf node5 = {3}; // Only reachable from node5
+
+    // Test the inialisation
+    REQUIRE(node4.count == 10);
+
+    // Link node1 and node2 together
+    link(&node1, &node2);
+
+    // Test that node1 and node2 are now linked
+    REQUIRE(node1.neighbours.front() == &node2);
+    REQUIRE(node2.neighbours.front() == &node1);
+
+    // Link the rest of the nodes
+    link(&node2, &node3);
+    link(&node3, &node4);
+    link(&node4, &node5);
+
+    // Assume we start with node 1, and want to assign them to cluster 1
+    Cluster* cluster1 = new Cluster(1);
+
+    // First, we must find the maximum node reachable from node1
+    NLeaf* node = max_neighbour(&node1);
+
+    // This should be node3
+    REQUIRE(node == &node3);
+
+    // Next, we assign all nodes
+    assignDirectionalCluster(node, cluster1);
+
+    // Then, the first three nodes should be assigned to cluster 1
+    REQUIRE(node1.cluster->id == 1);
+    REQUIRE(node2.cluster->id == 1);
+    REQUIRE(node3.cluster->id == 1);
+
+    // The last two node should not be assigned
+    REQUIRE(!node4.cluster);
+    REQUIRE(!node5.cluster);
+
+    // Now we assign node4 to cluster2
+    Cluster* cluster2 = new Cluster(2);
+    assignDirectionalCluster(&node4, cluster2);
+    REQUIRE(node4.cluster->id == 2);
+    REQUIRE(node5.cluster->id == 2);
+
+    // Check that the cluster size is correct
+    REQUIRE(cluster1->size == 14);
+    REQUIRE(cluster2->size == 13);
+
+    // Check that the maxleaf is correct
+    REQUIRE(cluster1->maxLeaf == &node3);
+    REQUIRE(cluster2->maxLeaf == &node4);
+
+    // Check that the maxCount is correct
+    REQUIRE(cluster1->maxCount == 8);
+    REQUIRE(cluster2->maxCount == 10);
 }

--- a/tests/test_cluster.cc
+++ b/tests/test_cluster.cc
@@ -30,6 +30,7 @@ TEST_CASE("Test walking node whose neighbour is already assigned", "[cluster]"){
     NLeaf assigned_neighbour;
     Cluster* c = new Cluster(2);
     assigned_neighbour.cluster = c;
+    assigned_neighbour.count = 2;
     leaf.neighbours.push_back(&assigned_neighbour);
     REQUIRE(max_neighbour(&leaf) == &leaf);
 }

--- a/tests/test_lib.cc
+++ b/tests/test_lib.cc
@@ -1,0 +1,7 @@
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+
+int main(int argc, char** argv) {
+  return Catch::Session().run(argc, argv);
+}


### PR DESCRIPTION
I did not implement the 'adjacency' method from the umi-tools publication, since that method performed poorly, and it requires complete knowledge of all edges between nodes to perform. In contrast, directional clustering only requires knowledge about the direct neighbours.