### PR TITLE
Create output directory

### DIFF
--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -1,5 +1,6 @@
 #include <string>
 #include <tuple>
+#include <filesystem>
 
 #include "../lib/commandIO/src/commandIO.h"
 #include "../lib/fastp/src/writer.h"
@@ -313,6 +314,7 @@ void dedup(
 
   vector<Cluster*> clusters = findClusters(trie, maximum, log);
 
+  std::filesystem::create_directories(dirName);
   if (filter) {
     writeFiltered(trie, files, length, dirName, log);
   }

--- a/src/dedup.cc
+++ b/src/dedup.cc
@@ -1,6 +1,6 @@
+#include <filesystem>
 #include <string>
 #include <tuple>
-#include <filesystem>
 
 #include "../lib/commandIO/src/commandIO.h"
 #include "../lib/fastp/src/writer.h"
@@ -11,6 +11,7 @@
 #include "leaf.h"
 #include "log.h"
 
+using std::filesystem::create_directories;
 using std::ios;
 
 /*!
@@ -314,7 +315,7 @@ void dedup(
 
   vector<Cluster*> clusters = findClusters(trie, maximum, log);
 
-  std::filesystem::create_directories(dirName);
+  create_directories(dirName);
   if (filter) {
     writeFiltered(trie, files, length, dirName, log);
   }


### PR DESCRIPTION
# Submit a pull request
Thank you for submitting a pull request. To speed up the review process, please
ensure that everything below is true:

1. This is not a duplicate of an [existing pull request][1].
2. No existing features have been broken without good reason.
3. Your commit messages are detailed
4. The code style [guidelines][2] have been followed.
5. Documentation has been updated to reflect your changes.
6. Tests have been added or updated to reflect your changes.
7. All tests pass.

Any questions should be directed to @jfjlaros.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details
Added functionality to automatically create the specified target folder

## Breaking Changes
The original behaviour was slighly inconsistent. When running dedup with default settings (i.e. writing the deduplicated fastq files), it would crash if the target folder did not exist. However, when only writing the statistics, but not the deduplicated fastq files (by passing `-q -s`), it would silently fail and exit with 0 if the output folder was missing.


## Issues Fixed
See above

## Other Relevant Information
None

[1]: https://github.com/jfjlaros/dedup/pulls
[2]: https://github.com/jfjlaros/dedup/blob/master/docs/CONTRIBUTING.md#code-style
