### PR TITLE
Build static release for semantic versioning tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build static binary for humid
         run: |
-          cd src && make humid
+          cd src && make static && mv static humid
 
       - name: Upload static binary as artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish release on tag creation
 on:
   push:
     tags:
-      - '*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   package:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,4 +28,4 @@ Static compilation
     ./configure
     make
     cd ../../src
-    make humid
+    make static

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ OBJS := $(addsuffix .o, $(LIBS))
 
 all: $(EXEC)
 
-humid: $(MAIN) $(OBJS)
+static: $(MAIN) $(OBJS)
 	$(CC) $(CC_ARGS) -o $@ $^ $(LD_ARGS) $(LD_STATIC_ARGS)
 
 $(EXEC): $(MAIN) $(OBJS)
@@ -39,6 +39,6 @@ clean:
 	rm -f $(OBJS)
 
 distclean: clean
-	rm -f $(EXEC) humid
+	rm -f $(EXEC) static
 
 doc: ../docs/cli.rst


### PR DESCRIPTION
Only create a release for tags of the form `v1.0.0`, `v29.477.12`, etc.