### PR TITLE
Various bug fixes related to non-default word size

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           echo $EVENT_CONTEXT
 
       - name: Upload archive as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-tar
           path: humid-${{ env.RELEASE_VERSION}}.tar.gz
@@ -69,7 +69,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
 
       - name: Download tar archive
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-tar
 
@@ -85,7 +85,7 @@ jobs:
           cd src && make static && mv static humid
 
       - name: Upload static binary as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-binary
           path: src/humid
@@ -106,12 +106,12 @@ jobs:
           run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
         - name: Download release tarball
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: release-tar
 
         - name: Download release binary
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: release-binary
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=====
+=========================================
 HUMID: reference free FastQ deduplication
-=====
+=========================================
 
 .. image:: https://img.shields.io/github/last-commit/jfjlaros/HUMID.svg
    :target: https://github.com/jfjlaros/HUMID/graphs/commit-activity

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,4 +8,5 @@
    install
    cli
    usage
+   troubleshooting
    credits

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,6 +1,16 @@
 Installation
 ============
 
+You can download a static binary directly from _github, or use any of the
+alternative installation methods listed below
+
+From conda_
+-----------
+
+::
+
+    conda install humid
+
 From source
 -----------
 
@@ -29,3 +39,6 @@ Static compilation
     make
     cd ../../src
     make static
+
+.. _conda: https://anaconda.org/bioconda/humid
+.. _github: https://github.com/jfjlaros/HUMID/releases

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,8 +1,9 @@
 Installation
 ============
 
-You can download a static binary directly from _github, or use any of the
+You can download a static binary directly from github_, or use any of the
 alternative installation methods listed below
+
 
 From conda_
 -----------

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -1,0 +1,18 @@
+Troubleshooting
+===============
+
+If you believe you have encountered a bug, please open an issue on github_.
+
+Segmentatio fault during cluster calculation
+--------------------------------------------
+If you see a message similar to the one below, it is possible that HUMID has
+run out of stack space::
+
+  Reading data... done. (22m42s)
+  Calculating neighbours using Hamming distance... done. (17m10s)
+  Calculating maximum clusters... Segmentation fault (core dumped)
+
+To resolve this, you can increase the maximum stack size on your system using
+``ulimit -Ss 102400``.
+
+.. _github: https://github.com/jfjlaros/HUMID/issues

--- a/src/humid.cc
+++ b/src/humid.cc
@@ -1,6 +1,7 @@
 #include <filesystem>
 #include <string>
 #include <tuple>
+#include <format>
 
 #include "../lib/commandIO/src/commandIO.h"
 #include "../lib/fastp/src/writer.h"
@@ -71,6 +72,18 @@ tuple<size_t, size_t> readData(
   size_t headerUMISize;
   vector<size_t> ntToTake;
   tie(headerUMISize, ntToTake) = preCompute(files, wordLength);
+
+  time_t nt_start {startMessage(log, "Determing nucleotides to take")};
+  endMessage(log, nt_start);
+
+  // Print the nucleotides to take from UMI and each file
+  string msg = std::format("umi: {}", headerUMISize);
+  size_t i {1};
+  for (size_t nt: ntToTake) {
+    msg += std::format("\nfile{}: {}", i, nt);
+    i++;
+  }
+  log << msg.c_str() << "\n";
 
   time_t start {startMessage(log, "Reading data")};
   size_t total {0};

--- a/src/humid.cc
+++ b/src/humid.cc
@@ -41,9 +41,14 @@ tuple<size_t, vector<size_t>> preCompute(
   // Peek at the header of the first read in the first file to get the UMI size.
   size_t headerUMISize {peekUMI(files.front())};
 
+  // Ensure we do not take negative nucleotides from the files
+  size_t fromFile = 0;
+  if (wordLength > headerUMISize) {
+    size_t fromFile = wordLength - headerUMISize;
+  }
   // Calculate how many nucleotes to take from each read. Any remainder will be
   // taken from the last file.
-  vector<size_t> ntToTake {ntFromFile(files.size(), wordLength - headerUMISize)};
+  vector<size_t> ntToTake {ntFromFile(files.size(), fromFile)};
 
   return tuple<size_t, vector<size_t>>(headerUMISize, ntToTake);
 }
@@ -60,7 +65,6 @@ tuple<size_t, vector<size_t>> preCompute(
 tuple<size_t, size_t> readData(
     Trie<4, NLeaf>& trie, vector<string> const files, size_t const wordLength,
     ofstream& log) {
-  time_t start {startMessage(log, "Reading data")};
 
   // Pre calculate some values so that we do not have to re-calculate them for
   // every single read.
@@ -68,6 +72,7 @@ tuple<size_t, size_t> readData(
   vector<size_t> ntToTake;
   tie(headerUMISize, ntToTake) = preCompute(files, wordLength);
 
+  time_t start {startMessage(log, "Reading data")};
   size_t total {0};
   size_t usable {0};
   for (vector<Read*> const& reads: readFiles(files)) {

--- a/src/humid.cc
+++ b/src/humid.cc
@@ -83,7 +83,7 @@ tuple<size_t, size_t> readData(
   endMessage(log, nt_start);
 
   // Print the nucleotides to take from UMI and each file
-  string msg = std::format("umi: {}", headerUMISize);
+  string msg = std::format("header: {}", headerUMISize);
   size_t i {1};
   for (size_t nt: ntToTake) {
     msg += std::format("\nfile{}: {}", i, nt);

--- a/src/humid.cc
+++ b/src/humid.cc
@@ -45,11 +45,17 @@ tuple<size_t, vector<size_t>> preCompute(
   // Ensure we do not take negative nucleotides from the files
   size_t fromFile = 0;
   if (wordLength > headerUMISize) {
-    size_t fromFile = wordLength - headerUMISize;
+    fromFile = wordLength - headerUMISize;
   }
+
   // Calculate how many nucleotes to take from each read. Any remainder will be
   // taken from the last file.
   vector<size_t> ntToTake {ntFromFile(files.size(), fromFile)};
+
+  // Ensure we do not take more than wordLength from the UMI header
+  if (wordLength < headerUMISize) {
+    headerUMISize = wordLength;
+  }
 
   return tuple<size_t, vector<size_t>>(headerUMISize, ntToTake);
 }

--- a/tests/test_fastq.cc
+++ b/tests/test_fastq.cc
@@ -148,6 +148,10 @@ TEST_CASE("Test dividing nucleotides over files") {
   //3 files, 9 nt
   expected = { 3, 3, 3 };
   REQUIRE(ntFromFile(3, 9) == expected);
+
+  // 3 files, 0 nt (we only use the UMI)
+  expected = { 0, 0, 0 };
+  REQUIRE(ntFromFile(3, 0) == expected);
 }
 
 TEST_CASE("Test extracting only the large UMI from the header"){


### PR DESCRIPTION
## Pull Request Details
This pull request fixes two bugs:
1. A bug where we always use the full UMI from the header, even if the specified word size is smaller
2. A bug where HUMID crashes if the UMI in the header is larger than the specified word size.

## Breaking Changes
1. Added additional output to the log file to show how many nucleotides are taken from the header and each file:
```text
Determing nucleotides to take... done. (0m0s)
header: 8
file1: 8
file2: 8
Reading data... done. (0m0s)
Calculating neighbours using Hamming distance... done. (0m1s)
Calculating directional clusters... done. (0m0s)
Calculating count and neighbour stats... done. (0m0s)
```