### PR TITLE
Assign filtered reads to cluster 0 when writing annotated FastQ file

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,5 +8,6 @@
    install
    cli
    usage
+   output
    troubleshooting
    credits

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -25,7 +25,7 @@ inspected directly.
 
 stats.dat
 ~~~~~~~~~
-This is probably the most usefull file, it contains the statistics about the number of reads in each of the following categories.
+This is probably the most useful file, it contains the statistics about the number of reads in each of the following categories.
 
 .. list-table:: stats.dat
   :header-rows: 1
@@ -43,13 +43,12 @@ This is probably the most usefull file, it contains the statistics about the num
 
 neigh.dat
 ~~~~~~~~~
-This file contains counts for the number of neighbours for each usable read. The first number is the `number of neighbours` and the second number is how many distinct reads have this number of neighbours.
+This file contains a histogram of the number of reads with a given number of neighbours. The first number is the `number of neighbours` and the second number is how many distinct reads have this number of neighbours.
 
 clusters.dat
 ~~~~~~~~~~~~
-This file contains the counts for the size of each cluster. The first number is the `cluster size`, the second number is how many clusters are of the specified size.
+This file contains a histogram of the number of clusters of a given size. The first number is the `cluster size`, the second number is how many clusters are of the specified size.
 
 counts.dat
 ~~~~~~~~~~
-This file contains the counts for exact duplicates in the usable input reads. The first number is the `number of exact duplicates` and the second number is how many distinct reads have this number of exact duplicates.
-
+This file contains a histogram of the number of exact duplicates in the usable input reads. The first number is the `number of exact duplicates` and the second number is how many distinct reads have this number of exact duplicates.

--- a/docs/output.rst
+++ b/docs/output.rst
@@ -1,0 +1,55 @@
+Output
+======
+
+FastQ output
+------------
+By default, HUMID will write the deduplicated FastQ files in the current
+folder, using the `_dedup` suffix in the file name to distinguish them from the
+input FastQ files.
+
+By specifying the `-a` flag, HUMID will output the annotated FastQ files using
+the `_annotated` suffix in the file name. For each read in the output, the
+`cluster_id` will be appended to the end of the read header, using a colon
+(`:`) as a separator.
+
+**Special case**: The cluster with id `0` has been reserved for reads that
+could not be classified. For example because there were not enough bases
+available to create a `word`, or because the word contains one or more N bases.
+
+
+Statistics
+----------
+Run HUMID with the `-s` flag to generate deduplication statistics. These
+statics files can be visualized using MultiQC version 1.14 or later, or
+inspected directly.
+
+stats.dat
+~~~~~~~~~
+This is probably the most usefull file, it contains the statistics about the number of reads in each of the following categories.
+
+.. list-table:: stats.dat
+  :header-rows: 1
+
+  * - Field
+    - Definition
+  * - total
+    - Total number of input reads
+  * - usable
+    - Total number of reads that were usable (did not contain N)
+  * - unique
+    - Total number of distinct input
+  * - clusters
+    - Total number unique reads after clustering and deduplication
+
+neigh.dat
+~~~~~~~~~
+This file contains counts for the number of neighbours for each usable read. The first number is the `number of neighbours` and the second number is how many distinct reads have this number of neighbours.
+
+clusters.dat
+~~~~~~~~~~~~
+This file contains the counts for the size of each cluster. The first number is the `cluster size`, the second number is how many clusters are of the specified size.
+
+counts.dat
+~~~~~~~~~~
+This file contains the counts for exact duplicates in the usable input reads. The first number is the `number of exact duplicates` and the second number is how many distinct reads have this number of exact duplicates.
+

--- a/src/humid.cc
+++ b/src/humid.cc
@@ -174,7 +174,7 @@ vector<Cluster*> findClusters(
     start = startMessage(log, "Calculating directional clusters");
   }
   vector<Cluster*> clusters;
-  size_t id {0};
+  size_t id {1};
   for (Result<NLeaf> const& result: trie.walk()) {
     if (not result.leaf->cluster) {
       Cluster* cluster {new Cluster {id++}};
@@ -267,14 +267,20 @@ void writeAnnotated(
 
   for (vector<Read*> const& reads: readFiles(files)) {
     Word word {makeWord(reads, ntToTake, headerUMISize)};
+
+    // Cluster ID 0 is special, and reserved for reads that could not be clustered
+    size_t cluster_id = {0};
+
+    // For reads that have been clustered, we find the cluster ID in the trie
     if (not word.filtered) {
       Node<4, NLeaf>* node {trie.find(word.data)};
+      cluster_id = node->leaf->cluster->id;
+    }
 
-      for (size_t i {0}; i < reads.size(); i++) {
-        *reads[i]->mName += ':' + to_string(node->leaf->cluster->id);
-        string s {reads[i]->toString()};
-        outFiles[i]->write(s.c_str(), s.size());
-      }
+    for (size_t i {0}; i < reads.size(); i++) {
+      *reads[i]->mName += ':' + to_string(cluster_id);
+      string s {reads[i]->toString()};
+      outFiles[i]->write(s.c_str(), s.size());
     }
   }
 


### PR DESCRIPTION
## Pull Request Details
Make cluster id 0 a special case for reads that could not be clustered, for example because they contain `N` characters or are too short. Since 0 is reserved, regular clusters start counting from 1.

## Breaking Changes
The only changes for the user are that all reads from the input file will be present in the annotated output file (in the same order), and that the cluster id's now start from 1.

## Fixes
This fixes an issue where the annotated FastQ output file contains fewer reads than the input file in cases where there are reads which are too short or contain `N` characters.